### PR TITLE
Fix confusing evaluation output

### DIFF
--- a/src/Evaluate.java
+++ b/src/Evaluate.java
@@ -66,7 +66,7 @@ public class Evaluate {
 
             correct += retValues[0];goldTotal += retValues[1];predTotal += retValues[2];
             predictedSegmentations.put(entry.getKey(), predSeg);
-            if(retValues[1] != retValues[2])
+            if(retValues[0] != retValues[1])
                 incorrectSegmentations.put(entry.getKey(), predSeg+" : "+entry.getValue());
             else
                 correctSegmentations.put(entry.getKey(), predSeg+" : "+entry.getValue());


### PR DESCRIPTION
Currently segmentations are deemed correct if the amount of segments are the same as in the gold segmentation. This has no effect on the precision/recall/F1 calculations, but it results in incorrect output which is at best confusing and at worst destroys trust in the algorithm. 

This change deems words correct if all segmentations are the same as in the gold segmentation, which seems more logical. 